### PR TITLE
Fix main entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "aws-to-slack",
   "version": "1.1.5",
   "description": "Forward AWS Notification Messages to Slack",
-  "main": "handler/index.js",
+  "main": "src/index.js",
   "scripts": {
     "test": "node src/test",
     "lint": "eslint . --ext .jsx --ext .js || exit 0"


### PR DESCRIPTION
Fixes main entry point from `handler/` to `src/`.
This change is required to use aws-to-slack as a package dependency (ie. `require('aws-to-slack')`).