### PR TITLE
Allow cloudformation template to specify s3 release uri

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+cloudformation.yaml
+README.md

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 AWS_CLI?=/usr/local/bin/aws
+S3_PATH?=aws-to-slack
 TEMP_PATH=.temp
 RELEASE_ZIP=build/release.zip
 
@@ -27,5 +28,5 @@ package:
 
 .PHONY: publish
 publish:
-	@"$(AWS_CLI)" s3 cp "./cloudformation.yaml" "s3://aws-to-slack/" --acl public-read
-	@"$(AWS_CLI)" s3 cp "$(RELEASE_ZIP)" "s3://aws-to-slack/" --acl public-read
+	@"$(AWS_CLI)" s3 cp "./cloudformation.yaml" "s3://$(S3_PATH)/" --acl public-read
+	@"$(AWS_CLI)" s3 cp "$(RELEASE_ZIP)" "s3://$(S3_PATH)/" --acl public-read

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![license](https://img.shields.io/github/license/arabold/aws-to-slack.svg)](https://github.com/arabold/aws-to-slack/blob/master/LICENSE)
 [![dependencies](https://img.shields.io/david/arabold/aws-to-slack.svg)](https://www.npmjs.com/package/aws-to-slack)
 
-
 Forward AWS CloudWatch Alarms and other notifications from Amazon SNS to Slack.
 
 ![CloudWatch Alarm Example](./docs/alert-example-cw.png)
@@ -12,31 +11,34 @@ Forward AWS CloudWatch Alarms and other notifications from Amazon SNS to Slack.
 ![Elastic Beanstalk Example](./docs/alert-example-eb.png)
 
 ## What is it?
+
 _AWS-to-Slack_ is a Lambda function written in Node.js that forwards alarms and
 notifications to a dedicated [Slack](https://slack.com) channel. It self-hosted
 in your own AWS environment and doesn't have any 3rd party dependencies other
 than the Google Charts API for rendering CloudWatch metrics.
 
 Supported notification formats:
-* AWS Code Build
-* AWS Health Dashboard 🆕
-* Amazon Inspector
-* Amazon SES Received Notifications 🆕
-* CloudWatch Alarms (incl. Metrics)
-* Elastic Beanstalk
-* RDS
-* Generic SNS messages
-* Plain text messages
+
+- AWS Code Build
+- AWS Health Dashboard 🆕
+- Amazon Inspector
+- Amazon SES Received Notifications 🆕
+- CloudWatch Alarms (incl. Metrics)
+- Elastic Beanstalk
+- RDS
+- Generic SNS messages
+- Plain text messages
 
 Additional formats will be added; Pull Requests are welcome!
 
 ## Try!
-Ready to try it for yourself? 
+
+Ready to try it for yourself?
 
 **If you are in the us-east-1 AWS Region:**
 
 Installation into your own AWS environment is as
-simple as pressing the button below 
+simple as pressing the button below
 
 [![Launch CloudFormation Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=aws-to-slack&templateURL=https://s3.amazonaws.com/aws-to-slack/cloudformation.yaml)
 
@@ -47,6 +49,7 @@ Please refer to the installation instructions below
 ## Installation
 
 ### Step 1 - Setup Slack
+
 The Lambda function communicates with Slack through a Slack webhook
 [webhook](https://your-slack-domain.slack.com/apps/manage). Note that you can either create an app, or a custom integration > Incoming webhook (easier, will only let you add a webhook)
 
@@ -62,7 +65,7 @@ The Lambda function communicates with Slack through a Slack webhook
 
 ### Step 2 - Configure & Launch the CloudFormation Stack
 
-Note that the AWS region will be the region from which you launch the CloudFormation wizard, which will also scope the resources (SNS, etc.) to that region. 
+Note that the AWS region will be the region from which you launch the CloudFormation wizard, which will also scope the resources (SNS, etc.) to that region.
 
 **If you are launching the CloudFormation Wizard for us-east-1 resources:**
 
@@ -74,7 +77,7 @@ by simply pressing the following button:
 
 **If you are not in the us-east-1 AWS Region:**
 
-- Download the release.zip file and upload it so some AWS S3 Bucket (it only works with s3 URLs, plus the format must be `s3://your-bucket/path-to-file`. 
+- Download the release.zip file and upload it so some AWS S3 Bucket (it only works with s3 URLs, plus the format must be `s3://your-bucket/path-to-file`.
 - Give public access to this file in S3
 - Make a copy of the cloudformation.yaml file, edit the s3 URL so that it points to your newly uploaded file s3 URL
 - Go to the CloudFormation interface from you region (you can click one of the links above, but make sure to change the region to yours) then click on "upload from file" and send your modified `cloudformation.yaml` file
@@ -98,17 +101,26 @@ switch to the "Triggers" tab and subscribe for all events you're interested in.
 
 ![Lambda Triggers](./docs/config-lambda-triggers.png)
 
-
 ### Setting Up AWS CodeBuild
+
 CodeBuild integration was suggested by [ericcj](https://github.com/ericcj) and is based on
 the Medium post [Monitor your AWS CodeBuilds via Lambda and Slack](https://hackernoon.com/monitor-your-aws-codebuilds-via-lambda-and-slack-ae2c621f68f1) by
-Randy Findley. 
+Randy Findley.
 
 To enable CodeBuild notifications add a new _CloudWatch Event Rule_, choose _CodeBuild_
 as source and _CodeBuild Build State Change_ as type. As Target select the `aws-to-slack`
 Lambda. You can leave all other settings as is. Once your rule is created all CodeBuild
 build state events will be forwarded to your Slack channel.
 
+### Publishing to S3
+
+Need to publish your changes to the cloudformation tempate or the release.zip to your own AWS account? By default, `make publish` will copy the `cloudformation.yaml` template and `build/release.zip` to the `aws-to-slack` s3 bucket. You can specify a bucket that you own by setting `S3_PATH` when running `make publish`.
+
+	S3_PATH=my-org-devops make publish
+
+Or you can add a specific folder to the path. This is helpful when you want to publish this cloudformation template along side other organizational templates.
+
+	S3_PATH=my-org-devops/cloudformation/templates/aws-to-slack make publish
 
 ## Contributing
 
@@ -126,5 +138,4 @@ make deps
 make package
 ```
 
-To generate a new `release.zip` in the `build` folder. Upload this zip to your
-AWS Lambda function and you're good to go.
+To generate a new `release.zip` in the `build` folder. Upload this zip to your AWS Lambda function and you're good to go.

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -2,6 +2,10 @@ AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 
 Parameters:
+  CodeUri:
+    Description: The S3 URI of the release zip file
+    Type: String
+    Default: s3://aws-to-slack/release.zip
   HookUrl:
     Description: Slack webhook URL; see https://example.slack.com/apps/
     Type: String
@@ -18,7 +22,7 @@ Resources:
     Properties:
       Handler: src/index.handler
       Runtime: nodejs6.10
-      CodeUri: s3://aws-to-slack/release.zip
+      CodeUri: !Ref CodeUri
       MemorySize: 256
       Timeout: 10
       Policies: CloudWatchReadOnlyAccess


### PR DESCRIPTION
The ability to publish to my own s3 bucket might only be something that I want to do. Feel free to reject this pull request if you think it's not something that should be in the project.