### PR TITLE
Adds CodeCommit parsers for repo and pull request events

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,18 @@ as source and _CodeBuild Build State Change_ as type. As Target select the `aws-
 Lambda. You can leave all other settings as is. Once your rule is created all CodeBuild
 build state events will be forwarded to your Slack channel.
 
+### Setting Up AWS CodeCommit
+
+Similar to the CodeBuild integration, CodeCommit notifications are triggered by
+CloudWatch Event Rules. Create a new CloudWatch Event Rule, select _CodeCommit_
+as the source, and select one of the supported event types:
+
+* _CodeCommit Pull Request State Change_ - Will generate events when a pull
+  request is opened, closed, merged, or updated.
+* _CodeCommit Repository State Change_ - Will generate events when a branch
+  or tag reference is created, updated, or deleted.
+
+Add the `aws-to-slack` lambda as the target. No other settings are needed.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ than the Google Charts API for rendering CloudWatch metrics.
 
 Supported notification formats:
 * AWS Code Build
+* AWS CodeCommit
 * AWS Health Dashboard 🆕
 * Amazon Inspector
 * Amazon SES Received Notifications 🆕

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ function processIncoming(event) {
 		require("./parsers/codebuild"),
 		require("./parsers/ses-received"),
 		require("./parsers/codecommit/pullrequest"),
+		require("./parsers/codecommit/repository"),
 	];
 
 	// Execute all parsers and use the first successful result

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ function processIncoming(event) {
 		require("./parsers/inspector"),
 		require("./parsers/codebuild"),
 		require("./parsers/ses-received"),
+		require("./parsers/codecommit/pullrequest"),
 	];
 
 	// Execute all parsers and use the first successful result

--- a/src/parsers/codecommit/pullrequest.js
+++ b/src/parsers/codecommit/pullrequest.js
@@ -1,0 +1,93 @@
+"use strict";
+
+const BbPromise = require("bluebird"),
+	_ = require("lodash"),
+	Slack = require("../../slack");
+
+class CodeCommitPullRequestParser {
+
+	parse(event) {
+		return BbPromise.try(() => _.isObject(event) ? event : JSON.parse(event))
+		.catch(_.noop) // ignore JSON errors
+		.then(event => {
+			if (_.get(event, "source") !== "aws.codecommit") {
+				return BbPromise.resolve(false);
+			}
+
+			if (_.get(event, "detail-type") !== "CodeCommit Pull Request State Change") {
+				// Not of interest for us
+				return BbPromise.resolve(false);
+			}
+
+			const time = new Date(_.get(event, "time"));
+			const repoName = _.get(event, "detail.repositoryNames[0]");
+			const callerArn = _.get(event, "detail.callerUserArn");
+			const pullRequestId = _.get(event, "detail.pullRequestId");
+			const pullRequestEvent = _.get(event, "detail.event");
+			const pullRequestMerged = _.get(event, "detail.isMerged");
+			const pullRequestStatus = _.get(event, "detail.pullRequestStatus");
+			const pullRequestTitle = _.get(event, "detail.title");
+			const pullRequestUrl = `https://console.aws.amazon.com/codecommit/home?region=${event.region}#/repository/${repoName}/pull-request/${pullRequestId}`;
+			const fields = [];
+
+			let color = Slack.COLORS.neutral;
+			const baseTitle = `Pull Request #${pullRequestId}`;
+			let title = baseTitle;
+			if (pullRequestEvent === "pullRequestMergeStatusUpdated" && pullRequestStatus === "Closed" && pullRequestMerged === "True") {
+				title = `${baseTitle} was merged`;
+				color = Slack.COLORS.accent;
+			}
+			else if (pullRequestEvent === "pullRequestStatusChanged" && pullRequestStatus === "Closed" && pullRequestMerged === "False") {
+				title = `${baseTitle} was closed`;
+				color = Slack.COLORS.critical;
+			}
+			else if (pullRequestEvent === "pullRequestCreated") {
+				title = `${baseTitle} was opened`;
+				color = Slack.COLORS.ok;
+			}
+			else if (pullRequestEvent === "pullRequestSourceBranchUpdated") {
+				title = `${baseTitle} source branch was updated`;
+				color = Slack.COLORS.warning;
+			}
+
+			if (repoName) {
+				fields.push({
+					title: "Repository",
+					value: repoName,
+					short: true,
+				});
+			}
+
+			if (pullRequestTitle) {
+				fields.push({
+					title: "Pull Request Title",
+					value: pullRequestTitle,
+					short: true,
+				});
+			}
+
+			if (callerArn) {
+				fields.push({
+					title: "Caller ARN",
+					value: callerArn,
+				});
+			}
+
+			const slackMessage = {
+				attachments: [{
+					author_name: "AWS CodeCommit",
+					fallback: `${repoName}: ${title}`,
+					color: color,
+					title: title,
+					title_link: pullRequestUrl,
+					fields: fields,
+					mrkdwn_in: [ "title", "text" ],
+					ts: Slack.toEpochTime(time)
+				}]
+			};
+			return BbPromise.resolve(slackMessage);
+		});
+	}
+}
+
+module.exports = CodeCommitPullRequestParser;

--- a/src/parsers/codecommit/repository.js
+++ b/src/parsers/codecommit/repository.js
@@ -1,0 +1,92 @@
+"use strict";
+
+const BbPromise = require("bluebird"),
+	_ = require("lodash"),
+	Slack = require("../../slack");
+
+class CodeCommitRepositoryParser {
+
+	parse(event) {
+		return BbPromise.try(() => _.isObject(event) ? event : JSON.parse(event))
+		.catch(_.noop) // ignore JSON errors
+		.then(event => {
+			if (_.get(event, "source") !== "aws.codecommit") {
+				return BbPromise.resolve(false);
+			}
+
+			if (_.get(event, "detail-type") !== "CodeCommit Repository State Change") {
+				// Not of interest for us
+				return BbPromise.resolve(false);
+			}
+
+			const time = new Date(_.get(event, "time"));
+			const callerArn = _.get(event, "detail.callerUserArn");
+			const refName = _.get(event, "detail.referenceName");
+			const refType = _.get(event, "detail.referenceType");
+			const repoName = _.get(event, "detail.repositoryName");
+			const repoEvent = _.get(event, "detail.event");
+			const repoUrl = `https://console.aws.amazon.com/codecommit/home?region=${event.region}#/repository/${repoName}`;
+			const fields = [];
+
+			let color = Slack.COLORS.neutral;
+			let title = repoName;
+			if (repoEvent === "referenceCreated" && refType === "branch") {
+				title = `New branch created in repository ${repoName}`;
+			}
+			else if (repoEvent === "referenceUpdated" && refType === "branch") {
+				title = `New commit pushed to repository ${repoName}`;
+			}
+			else if (repoEvent === "referenceDeleted" && refType === "branch") {
+				title = `Deleted branch in repository ${repoName}`;
+			}
+			else if (repoEvent === "referenceCreated" && refType === "tag") {
+				title = `New tag created in repository ${repoName}`;
+			}
+			else if (repoEvent === "referenceUpdated" && refType === "tag") {
+				title = `Tag reference modified in repository ${repoName}`;
+			}
+			else if (repoEvent === "referenceDeleted" && refType === "tag") {
+				title = `Deleted tag in repository ${repoName}`;
+			}
+
+			if (repoName) {
+				fields.push({
+					title: "Repository",
+					value: repoName,
+					short: true,
+				});
+			}
+
+			if (refType) {
+				fields.push({
+					title: refType.charAt(0).toUpperCase() + refType.slice(1),
+					value: refName,
+					short: true,
+				});
+			}
+
+			if (callerArn) {
+				fields.push({
+					title: "Caller ARN",
+					value: callerArn,
+				});
+			}
+
+			const slackMessage = {
+				attachments: [{
+					author_name: "AWS CodeCommit",
+					fallback: `${repoName}: ${title}`,
+					color: color,
+					title: title,
+					title_link: repoUrl,
+					fields: fields,
+					mrkdwn_in: [ "title", "text" ],
+					ts: Slack.toEpochTime(time)
+				}]
+			};
+			return BbPromise.resolve(slackMessage);
+		});
+	}
+}
+
+module.exports = CodeCommitRepositoryParser;


### PR DESCRIPTION
This patch adds CodeCommit parsers for repository state changes and for pull request state changes. It uses CloudWatch Events, the same way that the CodeBuild configuration works.

Closes #22