### PR TITLE
Update function roles to get messages from commits

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -67,6 +67,7 @@ Resources:
       ManagedPolicyArns:
       - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       - arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess
+      - arn:aws:iam::aws:policy/AWSCodeCommitReadOnly
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
The AWSCodeCommitReadOnly role is necessary for the `codecommit/repository.js` parser to be able to read the commit messages.