### PR TITLE
Make sure KMS key is decrypted based on Lambda encryption code examples

### DIFF
--- a/src/slack.js
+++ b/src/slack.js
@@ -26,13 +26,13 @@ function shouldDecryptBlob(blob, isValid) {
 			&& (!isValid || isValid(blob))
 		) {
 			const kmsClient = new AWS.KMS();
-			kmsClient.decrypt({ CiphertextBlob: blob }, (err, data) => {
+			kmsClient.decrypt({ CiphertextBlob: new Buffer(blob, 'base64') }, (err, data) => {
 				if (err) {
 					console.error("Error decrypting (using as-is):", err);
 					resolve(blob);
 				}
 				else {
-					resolve(data.Plaintext);
+					resolve(data.Plaintext.toString('ascii'));
 				}
 			});
 		}


### PR DESCRIPTION
I've been trying to use the KMS encrypted ciphertext for webhook URL, generated via CLI and via Lambda encryption helpers, however none of them appear to work - when decrypting a "InvalidCiphertextException" is thrown.
Based on the Lambda encryption helper example code I've adjusted the decryption process which appears to have resolved the issue.

If this was indeed working as intended it would be great if @homeyjd could provide instructions on generating the encrypted string.