### PR TITLE
Export Lambda function ARN.

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -160,4 +160,4 @@ Outputs:
     Description: 'Lambda function ARN created by this stack.'
     Value: !GetAtt Function.Arn
     Export:
-      Name: aws-to-slack-arn
+      Name: !Sub 'aws-to-slack-channel-${Channel}-FunctionArn'

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -156,3 +156,8 @@ Outputs:
   LambdaFunction:
     Description: 'Lambda function name created by this stack.'
     Value: !Ref Function
+  LambdaFunctionARN:
+    Description: 'Lambda function ARN created by this stack.'
+    Value: !GetAtt Function.Arn
+    Export:
+      Name: aws-to-slack-arn


### PR DESCRIPTION
Export the Lambda function ARN. Makes it easy to Fn::Import it into other templates.