### PR TITLE
Update from NodeJS 8 to NodeJS 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8.10
+      - image: circleci/node:10.16.3
     working_directory: ~/repo
 
     steps:

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -48,7 +48,7 @@ Resources:
     Properties:
       Handler: src/index.handler
       Role: !GetAtt FunctionRole.Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       MemorySize: 256
       Timeout: 15 # Cross-region metrics lookup requires at least 10s
       Code:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Forward AWS Notification Messages to Slack",
   "main": "src/index.js",
   "engines": {
-    "node": ">=8.10.0"
+    "node": ">=10.16.3"
   },
   "scripts": {
     "test": "jest test",

--- a/src/slack.js
+++ b/src/slack.js
@@ -26,7 +26,7 @@ function shouldDecryptBlob(blob, isValid) {
 			&& (!isValid || isValid(blob))
 		) {
 			const kmsClient = new AWS.KMS();
-			kmsClient.decrypt({ CiphertextBlob: new Buffer(blob, 'base64') }, (err, data) => {
+			kmsClient.decrypt({ CiphertextBlob: Buffer.from(blob, 'base64') }, (err, data) => {
 				if (err) {
 					console.error("Error decrypting (using as-is):", err);
 					resolve(blob);


### PR DESCRIPTION
Updating from NodeJS 8 to NodeJS 10 due to AWS deprecation.

> The Node community has decided to end support for Node.js 8.x on December 31, 2019. From this date forward, Node.js 8.x will stop receiving bug fixes, security updates, and/or performance improvements. To ensure that your new and existing functions run on a supported and secure runtime, language runtimes that have reached their EOL are deprecated in AWS.
>For Node.js 8.x, there will be 2 stages to the runtime deprecation process:
>1. Disable Function Create – Beginning January 6, 2020, customers will no longer be able to create functions using Node.js 8.10
>2. Disable Function Update – Beginning February 3, 2020, customers will no longer be able to update functions using Node.js 8.10

Change summary:
* Bumped Cloudformation from nodejs8.10 to nodejs10.x
* Bumped CircleCI from 8.10 to 10.16.3 (due to the fact AWS references this version as equivalent to 10.x [here](https://docs.aws.amazon.com/lambda/latest/dg/programming-model.html))
* Fixed Buffer deprecation notice

Would be great if CircleCI and Cloudformation was tested independently - I am not using either one therefore cannot confirm if the changes I made work. In Terraform only the runtime attribute required changing therefore I'm quite certain it's the same in Cloudformation.
