### PR TITLE
Adjusted Color Code and Severity to match AWS Docs

### DIFF
--- a/src/parsers/guardduty.js
+++ b/src/parsers/guardduty.js
@@ -236,12 +236,12 @@ exports.parse = event => {
 		});
 	}
 
-	let color = event.COLORS.neutral;
-	if (severity === 1) {
-		color = event.COLORS.critical;
-	}
-	else if (severity === 2) {
+	let color = event.COLORS.neutral; //low severity below 4
+	if (severity > 4) { //medium seveirty between 4 and 7
 		color = event.COLORS.warning;
+	}
+    	if (severity > 7) { //high sevirity above 7
+		color = event.COLORS.critical;
 	}
 
 	return event.attachmentWithDefaults({


### PR DESCRIPTION
Updated Guardduty parses to reflect correct guard duty severity with appropriate Low, Medium and High Color Coding 
This has been added to match Color codes based on AWS Guard duty documentation: https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_findings.html#guardduty_findings-severity